### PR TITLE
Ctrl+Shift+P is defauft private browsing

### DIFF
--- a/src/ZenKeyboardShortcuts.mjs
+++ b/src/ZenKeyboardShortcuts.mjs
@@ -116,7 +116,7 @@ const kZenDefaultShortcuts = {
   zenToggleCompactModeToolbar: "Ctrl+Alt+T",
 
   // manage actions
-  zenToggleWebPanels: "Ctrl+Shift+P", 
+  zenToggleWebPanels: "Alt+P", 
 };
 
 // Section: ZenKeyboardShortcuts


### PR DESCRIPTION
Ctrl+Shift+P is defauft private browsing, change Sidebar shortcut to Alt+P instead.

https://github.com/zen-browser/desktop/issues/516