### PR TITLE
Resize views in split view

### DIFF
--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -3,7 +3,6 @@ var gZenViewSplitter = new (class {
     this._data = [];
     this.currentView = -1;
     this._tabBrowserPanel = null;
-    this._minAdjustmentWidth = 7;
     this.__modifierElement = null;
     this.__hasSetMenuListener = false;
 
@@ -170,6 +169,10 @@ var gZenViewSplitter = new (class {
       this._tabBrowserPanel = document.getElementById('tabbrowser-tabpanels');
     }
     return this._tabBrowserPanel;
+  }
+
+  get minResizeWidth() {
+    return Services.prefs.getIntPref('zen.splitView.min-resize-width');
   }
 
   /**
@@ -488,15 +491,15 @@ var gZenViewSplitter = new (class {
 
         const currentSize = splitData[dimension][gridIdx - 1];
         const neighborSize = splitData[dimension][gridIdx];
-        if (currentSize < this._minAdjustmentWidth && neighborSize < this._minAdjustmentWidth) {
+        if (currentSize < this.minResizeWidth && neighborSize < this.minResizeWidth) {
           return;
         }
         let max = false;
-        if (currentSize + percentageChange < this._minAdjustmentWidth) {
-          percentageChange = this._minAdjustmentWidth - currentSize;
+        if (currentSize + percentageChange < this.minResizeWidth) {
+          percentageChange = this.minResizeWidth - currentSize;
           max = true;
-        } else if (neighborSize - percentageChange < this._minAdjustmentWidth) {
-          percentageChange = neighborSize - this._minAdjustmentWidth;
+        } else if (neighborSize - percentageChange < this.minResizeWidth) {
+          percentageChange = neighborSize - this.minResizeWidth;
           max = true;
         }
         splitData[dimension][gridIdx - 1] += percentageChange;

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -508,9 +508,11 @@ var gZenViewSplitter = new (class {
     const stopListeners = () => {
       removeEventListener('mousemove', dragFunc);
       removeEventListener('mouseup', stopListeners);
+      setCursor('auto');
     }
     addEventListener('mousemove', dragFunc);
     addEventListener('mouseup', stopListeners);
+    setCursor(isVertical ? 'ew-resize' : 'n-resize');
   }
 
   updateGridSizes() {

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -477,7 +477,7 @@ var gZenViewSplitter = new (class {
 
     const isVertical = event.target.getAttribute('orient') === 'vertical';
     const dimension = isVertical ? 'widths' : 'heights';
-    const clientAxis = isVertical ? 'clientX' : 'clientY';
+    const clientAxis = isVertical ? 'screenX' : 'screenY';
 
     const gridIdx = event.target.getAttribute('gridIdx');
     let prevPosition = event[clientAxis];
@@ -515,21 +515,16 @@ var gZenViewSplitter = new (class {
 
   updateGridSizes() {
     const splitData = this._data[this.currentView];
-    if (splitData.widths.length === 1) {
-      this.tabBrowserPanel.style.gridTemplateColumns = '';
-    } else {
-      this.tabBrowserPanel.style.gridTemplateColumns = splitData.widths.slice(0, -1).map(
-          (w) => `calc(${w}% - 7px) 7px`
-      ).join(' ');
-    }
+    const columnGap = 'var(--zen-split-column-gap)';
+    const rowGap = 'var(--zen-split-row-gap)';
 
-    if (splitData.heights.length === 1) {
-      this.tabBrowserPanel.style.gridTemplateRows = '';
-    } else {
-      this.tabBrowserPanel.style.gridTemplateRows = splitData.heights.slice(0, -1).map(
-          (h) => `calc(${h}% - 7px) 7px`
-      ).join(' ');
-    }
+    this.tabBrowserPanel.style.gridTemplateColumns = splitData.widths.slice(0, -1).map(
+        (w) => `calc(${w}% - ${columnGap} * ${splitData.widths.length - 1}/${splitData.widths.length}) ${columnGap}`
+    ).join(' ');
+
+    this.tabBrowserPanel.style.gridTemplateRows = splitData.heights.slice(0, -1).map(
+        (h) => `calc(${h}% - ${rowGap} * ${splitData.heights.length - 1}/${splitData.heights.length}) ${rowGap}`
+    ).join(' ');
   }
 
   /**


### PR DESCRIPTION
Add resizing of views in split view.
![zen_FPrqaQGdpP](https://github.com/user-attachments/assets/6bdf4195-6d6f-40ef-a52c-293e1a6aa5d4)

Since splitters are inserted in #tabbrowser-tabpanels it may cause some bugs. But so far it seems to work pretty well.