### PR TITLE
fix: Await workspace save in `changeWorkspace`

### DIFF
--- a/src/ZenWorkspaces.mjs
+++ b/src/ZenWorkspaces.mjs
@@ -488,7 +488,7 @@ var ZenWorkspaces = {
     for (let workspace of workspaces.workspaces) {
       workspace.used = workspace.uuid === window.uuid;
     }
-    this.unsafeSaveWorkspaces(workspaces);
+    await this.unsafeSaveWorkspaces(workspaces);
     console.info('ZenWorkspaces: Changing workspace to', window.uuid);
     for (let i = 0; i < gBrowser.tabs.length; i++) {
       let tab = gBrowser.tabs[i];


### PR DESCRIPTION
This change ensures that the `unsafeSaveWorkspaces` function is called asynchronously. This is necessary to prevent blocking the UI thread while saving the workspaces.