### PR TITLE
Zen Mods: New properties config

### DIFF
--- a/src/ZenThemesCommon.mjs
+++ b/src/ZenThemesCommon.mjs
@@ -1,0 +1,97 @@
+var ZenThemesCommon = {
+  kZenOSToSmallName: {
+    WINNT: 'windows',
+    Darwin: 'macos',
+    Linux: 'linux',
+  },
+
+  kZenColors: ['#aac7ff', '#74d7cb', '#a0d490', '#dec663', '#ffb787', '#dec1b1', '#ffb1c0', '#ddbfc3', '#f6b0ea', '#d4bbff'],
+
+  get currentOperatingSystem() {
+    let os = Services.appinfo.OS;
+    return this.kZenOSToSmallName[os];
+  },
+
+  get themesRootPath() {
+    return PathUtils.join(PathUtils.profileDir, 'chrome', 'zen-themes');
+  },
+
+  get themesDataFile() {
+    return PathUtils.join(PathUtils.profileDir, 'zen-themes.json');
+  },
+
+  getThemeFolder(themeId) {
+    return PathUtils.join(this.themesRootPath, themeId);
+  },
+
+  getBrowser() {
+    if (!this.__browser) {
+      this.__browser = Services.wm.getMostRecentWindow('navigator:browser');
+    }
+
+    return this.__browser;
+  },
+
+  async getThemes() {
+    if (!this._themes) {
+      if (!(await IOUtils.exists(this.themesDataFile))) {
+        await IOUtils.writeJSON(this.themesDataFile, {});
+      }
+      this._themes = await IOUtils.readJSON(this.themesDataFile);
+    }
+    return this._themes;
+  },
+
+  async getThemePreferences(theme) {
+    const themePath = PathUtils.join(this.themesRootPath, theme.id, 'preferences.json');
+    if (!(await IOUtils.exists(themePath)) || !theme.preferences) {
+      return [];
+    }
+
+    const preferences = await IOUtils.readJSON(themePath);
+
+    // compat mode for old preferences, all of them can only be checkboxes
+    if (typeof preferences === 'object' && !Array.isArray(preferences)) {
+      console.warn(
+        `[ZenThemes]: Warning, ${theme.name} uses legacy preferences, please migrate them to the new preferences style, as legacy preferences might be removed at a future release. More information at: https://docs.zen-browser.app/themes-store/themes-marketplace-preferences`
+      );
+      const newThemePreferences = [];
+
+      for (let [entry, label] of Object.entries(preferences)) {
+        const [_, negation = '', os = '', property] = /(!?)(?:(macos|windows|linux):)?([A-z0-9-_.]+)/g.exec(entry);
+        const isNegation = negation === '!';
+
+        if (
+          (isNegation && os === this.currentOperatingSystem) ||
+          (os !== '' && os !== this.currentOperatingSystem && !isNegation)
+        ) {
+          continue;
+        }
+
+        newThemePreferences.push({
+          property,
+          label,
+          type: 'checkbox',
+          disabledOn: os !== '' ? [os] : [],
+        });
+      }
+
+      return newThemePreferences;
+    }
+
+    return preferences.filter(({ disabledOn = [] }) => !disabledOn.includes(this.currentOperatingSystem));
+  },
+
+  throttle(mainFunction, delay) {
+    let timerFlag = null;
+
+    return (...args) => {
+      if (timerFlag === null) {
+        mainFunction(...args);
+        timerFlag = setTimeout(() => {
+          timerFlag = null;
+        }, delay);
+      }
+    };
+  },
+};

--- a/src/ZenThemesImporter.mjs
+++ b/src/ZenThemesImporter.mjs
@@ -19,7 +19,7 @@ var gZenStylesheetManager = {
   async writeStylesheet(path, themes) {
     let content = kZenStylesheetThemeHeader;
     for (let theme of themes) {
-      if (!theme.enabled) {
+      if (theme.enabled !== undefined && !theme.enabled) {
         continue;
       }
       content += this.getThemeCSS(theme);
@@ -208,7 +208,11 @@ var gZenThemeImporter = new (class {
   }
 
   setDefaults(themesWithPreferences) {
-    for (const { preferences } of themesWithPreferences) {
+    for (const { preferences, enabled } of themesWithPreferences) {
+      if (enabled !== undefined && !enabled) {
+        continue;
+      }
+
       for (const { type, property, defaultValue } of preferences) {
         if (defaultValue === undefined) {
           continue;
@@ -251,7 +255,7 @@ var gZenThemeImporter = new (class {
     for (const { enabled, preferences, name } of themesWithPreferences) {
       const sanitizedName = `theme-${name?.replaceAll(/\s/g, '-')?.replaceAll(/[^A-z_-]+/g, '')}`;
 
-      if (!enabled) {
+      if (enabled !== undefined && !enabled) {
         const element = browser.document.getElementById(sanitizedName);
 
         if (element) {


### PR DESCRIPTION
- Ability for preferences to have a default value:
- Ability for preferences to have disable the property for multiple OS
- Removed: ![os]:[property] syntax (it is still available for legacy configuration files)
- Internal refactor of zen-settings.js and ZenThemeImporter.mjs so common functionality is now shared through ZenThemesCommon.mjs