### PR TITLE
Only flash sidebar when mouse leaves the browser

### DIFF
--- a/src/ZenCompactMode.mjs
+++ b/src/ZenCompactMode.mjs
@@ -1,5 +1,5 @@
 var gZenCompactModeManager = {
-  _flashSidebarTimeout: null,
+  _flashTimeouts: {},
 
   init() {
     Services.prefs.addObserver('zen.view.compact', this._updateEvent.bind(this));
@@ -8,6 +8,7 @@ var gZenCompactModeManager = {
     gZenUIManager.addPopupTrackingAttribute(this.sidebar);
     gZenUIManager.addPopupTrackingAttribute(document.getElementById('zen-appcontent-navbar-container'));
 
+    Services.prefs.addObserver('zen.tabs.vertical.right-side', this._updateSidebarIsOnRight.bind(this));
     this.addMouseActions();
   },
 
@@ -17,6 +18,13 @@ var gZenCompactModeManager = {
 
   set preference(value) {
     Services.prefs.setBoolPref('zen.view.compact', value);
+  },
+
+  get sidebarIsOnRight() {
+    if (this._sidebarIsOnRight) {
+      return this._sidebarIsOnRight;
+    }
+    return Services.prefs.getBoolPref('zen.tabs.vertical.right-side');
   },
 
   get sidebar() {
@@ -36,6 +44,10 @@ var gZenCompactModeManager = {
 
   _updatedSidebarFlashDuration() {
     this._flashSidebarDuration = Services.prefs.getIntPref('zen.view.compact.toolbar-flash-popup.duration');
+  },
+
+  _updateSidebarIsOnRight() {
+    this._sidebarIsOnRight = Services.prefs.getBoolPref('zen.tabs.vertical.right-side');
   },
 
   toggleSidebar() {
@@ -58,47 +70,100 @@ var gZenCompactModeManager = {
 
   get hoverableElements() {
     return [
-      this.sidebar,
-      document.getElementById('zen-appcontent-navbar-container'),
+      {
+        element: this.sidebar,
+        getScreenEdge: () => this.sidebarIsOnRight ? "right" : "left",
+      },
+      {
+        element: document.getElementById('zen-appcontent-navbar-container'),
+        getScreenEdge: () =>  "top",
+      }
     ];
   },
 
-  flashSidebar(element = null, duration = null) {
-    if (!element) {
-      element = this.sidebar;
-    }
-    if (!duration) {
-      duration = this.flashSidebarDuration;
-    }
+  flashSidebar(duration = this.flashSidebarDuration) {
     let tabPanels = document.getElementById('tabbrowser-tabpanels');
-    if (element.matches(':hover') || tabPanels.matches("[zen-split-view='true']")) {
+    if (!tabPanels.matches("[zen-split-view='true']")) {
+      this.flashElement(this.sidebar, duration, this.sidebar.id);
+    }
+  },
+
+  flashElement(element, duration, id, attrName = 'flash-popup') {
+    if (element.matches(':hover')) {
       return;
     }
-    if (this._flashSidebarTimeout) {
-      clearTimeout(this._flashSidebarTimeout);
+    if (this._flashTimeouts[id]) {
+      clearTimeout(this._flashTimeouts[id]);
     } else {
-      window.requestAnimationFrame(() => element.setAttribute('flash-popup', ''));
+      requestAnimationFrame(() => element.setAttribute(attrName, ''));
     }
-    this._flashSidebarTimeout = setTimeout(() => {
+    this._flashTimeouts[id] = setTimeout(() => {
       window.requestAnimationFrame(() => {
-        element.removeAttribute('flash-popup');
-        this._flashSidebarTimeout = null;
+        element.removeAttribute(attrName);
+        this._flashTimeouts[id] = null;
       });
     }, duration);
   },
 
+  clearFlashTimeout(id) {
+    clearTimeout(this._flashTimeouts[id]);
+    this._flashTimeouts[id] = null;
+  },
+
   addMouseActions() {
     for (let i = 0; i < this.hoverableElements.length; i++) {
-      this.hoverableElements[i].addEventListener('mouseenter', (event) => {
-        let target = this.hoverableElements[i];
+      const target = this.hoverableElements[i].element;
+      target.addEventListener('mouseenter', (event) => {
         target.setAttribute('zen-user-hover', 'true');
       });
 
-      this.hoverableElements[i].addEventListener('mouseleave', (event) => {
-        let target = this.hoverableElements[i];
-        this.flashSidebar(target, this.hideAfterHoverDuration);
-      });
+      if (this.hoverableElements[i].keepHoverDuration) {
+        target.addEventListener('mouseleave', (event) => {
+          this.flashSidebar(target, keepHoverDuration, target.id, 'hover-timeout');
+        });
+      }
     }
+
+    document.body.addEventListener('mouseleave', (event) => {
+      for (let i = 0; i < this.hoverableElements.length; i++) {
+        const target = this.hoverableElements[i].element;
+        const edge = this.hoverableElements[i].getScreenEdge();
+        if (!edge) return;
+        const orient = (edge === "left" || edge === "right" ? "vertical" : "horizontal");
+        if (
+          this._getNearestEdge(document.body, event.pageX, event.pageY) === edge
+          && this._positionIsAligned(orient, target, event.pageX, event.pageY, 7)
+        ) {
+          this.flashElement(target, this.hideAfterHoverDuration, target.id);
+
+          document.addEventListener('mousemove', () => {
+            target.removeAttribute('flash-popup');
+            this.clearFlashTimeout(target.id);
+          }, {once: true});
+        }
+      }
+    });
+  },
+
+  _getNearestEdge(element, posX, posY) {
+    const targetBox = element.getBoundingClientRect();
+    let smallestDistance = Infinity;
+    let closestEdge = "";
+    for (let edge of ["top", "bottom", "left", "right"]) {
+      const onXAxis = edge === "left" || edge === "right";
+      const distance = Math.abs( (onXAxis ? posX : posY) - targetBox[edge]);
+      if (smallestDistance > distance) {
+        smallestDistance = distance;
+        closestEdge = edge;
+      }
+    }
+    return closestEdge;
+  },
+
+  _positionIsAligned(axis = "x", element, x, y, error = 0) {
+    const bBox = element.getBoundingClientRect();
+    if (axis === "x") return bBox.top - error < y && y < bBox.bottom + error;
+    else return bBox.left - error < x && x < bBox.right + error;
   },
 
   toggleToolbar() {

--- a/src/ZenCompactMode.mjs
+++ b/src/ZenCompactMode.mjs
@@ -144,7 +144,7 @@ var gZenCompactModeManager = {
     ];
   },
 
-  flashSidebar(duration = this.flashSidebarDuration) {
+  flashSidebar(duration = lazyCompactMode.COMPACT_MODE_FLASH_DURATION) {
     let tabPanels = document.getElementById('tabbrowser-tabpanels');
     if (!tabPanels.matches("[zen-split-view='true']")) {
       this.flashElement(this.sidebar, duration, this.sidebar.id);

--- a/src/ZenCompactMode.mjs
+++ b/src/ZenCompactMode.mjs
@@ -134,11 +134,13 @@ var gZenCompactModeManager = {
     }
 
     document.documentElement.addEventListener('mouseleave', (event) => {
+      const screenEdgeCrossed = this._getCrossedEdge(event.pageX, event.pageY);
+      if (!screenEdgeCrossed) return;
       for (let entry of this.hoverableElements) {
-        if (!entry.screenEdge) continue;
+        if (screenEdgeCrossed !== entry.screenEdge) continue;
         const target = entry.element;
         const boundAxis = (entry.screenEdge === "right" || entry.screenEdge === "left" ? "y" : "x");
-        if (!this._crossedEdge(entry.screenEdge, event.pageX, event.pageY) || !this._positionInBounds(boundAxis, target, event.pageX, event.pageY, 7)) {
+        if (!this._positionInBounds(boundAxis, target, event.pageX, event.pageY, 7)) {
           continue;
         }
         this.flashElement(target, this.hideAfterHoverDuration, "has-hover" + target.id, 'zen-has-hover');
@@ -151,12 +153,14 @@ var gZenCompactModeManager = {
     });
   },
 
-  _crossedEdge(edge, posX, posY, element = document.documentElement, maxDistance = 10) {
+  _getCrossedEdge(posX, posY, element = document.documentElement, maxDistance = 10) {
     posX = Math.max(0, posX);
     posY = Math.max(0, posY);
     const targetBox = element.getBoundingClientRect();
-    const distance = Math.abs( ((edge === "right" || edge === "left") ? posX : posY) - targetBox[edge]);
-    return distance <= maxDistance;
+    return ["top", "bottom", "left", "right"].find((edge, i) => {
+      const distance = Math.abs((i < 2 ? posY : posX) - targetBox[edge]);
+      return distance <= maxDistance;
+    });
   },
 
   _positionInBounds(axis = "x", element, x, y, error = 0) {


### PR DESCRIPTION
Compact mode flash hover improvements:

- only retain 'zen-has-hover' when the mouse has left the screen on the side the element is attached (mouse overshoot).
this makes it so that using compact mode still feels very responsive as the popup will immediately close when the mouse is on the screen and not hovering it.

- Use documentElement to detect mouse leaves (for mouse overshoot).
 Since hover elements at the edge of the screen, they usually have very small hover boxes it can sometimes happen that the mouse passes over the element without 'mouseleave' firing.
 Using documentElement makes it so that the mouse leaving the screen is caught 100% of the time.

I kept a separate option to add hover delays to hover elements.