### PR TITLE
Fix rightside sidebar not always staying open when overshooting mouse.

### DIFF
--- a/src/ZenCompactMode.mjs
+++ b/src/ZenCompactMode.mjs
@@ -219,9 +219,9 @@ var gZenCompactModeManager = {
   },
 
   _getCrossedEdge(posX, posY, element = document.documentElement, maxDistance = 10) {
-    posX = Math.max(0, posX);
-    posY = Math.max(0, posY);
     const targetBox = element.getBoundingClientRect();
+    posX = Math.max(0, Math.min(posX, targetBox["right"]));
+    posY = Math.max(0, Math.min(posY, targetBox["bottom"]));
     return ["top", "bottom", "left", "right"].find((edge, i) => {
       const distance = Math.abs((i < 2 ? posY : posX) - targetBox[edge]);
       return distance <= maxDistance;

--- a/src/ZenCompactMode.mjs
+++ b/src/ZenCompactMode.mjs
@@ -220,8 +220,8 @@ var gZenCompactModeManager = {
 
   _getCrossedEdge(posX, posY, element = document.documentElement, maxDistance = 10) {
     const targetBox = element.getBoundingClientRect();
-    posX = Math.max(0, Math.min(posX, targetBox["right"]));
-    posY = Math.max(0, Math.min(posY, targetBox["bottom"]));
+    posX = Math.max(targetBox.left, Math.min(posX, targetBox.right));
+    posY = Math.max(targetBox.top, Math.min(posY, targetBox.bottom));
     return ["top", "bottom", "left", "right"].find((edge, i) => {
       const distance = Math.abs((i < 2 ? posY : posX) - targetBox[edge]);
       return distance <= maxDistance;


### PR DESCRIPTION
mouseleave is not 100% accurate, to get the side the mouse left on I bound the x and y value of the mouse by the border of documentElement. This wasn't done properly before. 