### PR TITLE
feat(workspaces): Store workspaces in a database

### DIFF
--- a/src/ZenWorkspaces.mjs
+++ b/src/ZenWorkspaces.mjs
@@ -62,11 +62,11 @@ var ZenWorkspaces = new class extends ZenMultiWindowFeature {
         const activeWorkspace = this._workspaceCache.workspaces.find(w => w.uuid === activeWorkspaceId);
         // Set the active workspace ID to the first one if the one with selected id doesn't exist
         if (!activeWorkspace) {
-          Services.prefs.setStringPref("zen.workspaces.active", this._workspaceCache.workspaces[0].uuid);
+          Services.prefs.setStringPref("zen.workspaces.active", this._workspaceCache.workspaces[0]?.uuid);
         }
       } else {
         // Set the active workspace ID to the first one if active workspace doesn't exist
-        Services.prefs.setStringPref("zen.workspaces.active", this._workspaceCache.workspaces[0].uuid);
+        Services.prefs.setStringPref("zen.workspaces.active", this._workspaceCache.workspaces[0]?.uuid);
       }
     }
     return this._workspaceCache;

--- a/src/ZenWorkspaces.mjs
+++ b/src/ZenWorkspaces.mjs
@@ -51,11 +51,6 @@ var ZenWorkspaces = new class extends ZenMultiWindowFeature {
     }
   }
 
-  // Wrorkspaces saving/loading
-  get _storeFile() {
-    return PathUtils.join(PathUtils.profileDir, 'zen-workspaces', 'Workspaces.json');
-  }
-
   async _workspaces() {
     if (!this._workspaceCache) {
       this._workspaceCache = { workspaces: await ZenWorkspacesStorage.getWorkspaces() };
@@ -77,10 +72,7 @@ var ZenWorkspaces = new class extends ZenMultiWindowFeature {
 
   async initializeWorkspaces() {
     Services.prefs.addObserver('zen.workspaces.enabled', this.onWorkspacesEnabledChanged.bind(this));
-    let file = new FileUtils.File(this._storeFile);
-    if (!file.exists()) {
-      await IOUtils.writeJSON(this._storeFile, {});
-    }
+
     await this.initializeWorkspacesButton();
     if (this.workspaceEnabled) {
       this._initializeWorkspaceCreationIcons();
@@ -175,8 +167,9 @@ var ZenWorkspaces = new class extends ZenMultiWindowFeature {
   }
 
   async removeWorkspace(windowID) {
+    let workspacesData = await this._workspaces();
     console.info('ZenWorkspaces: Removing workspace', windowID);
-    await this.changeWorkspace(json.workspaces.find((workspace) => workspace.uuid !== windowID));
+    await this.changeWorkspace(workspacesData.workspaces.find((workspace) => workspace.uuid !== windowID));
     this._deleteAllTabsInWorkspace(windowID);
     delete this._lastSelectedWorkspaceTabs[windowID];
     await ZenWorkspacesStorage.removeWorkspace(windowID);

--- a/src/ZenWorkspacesStorage.mjs
+++ b/src/ZenWorkspacesStorage.mjs
@@ -7,7 +7,7 @@ var ZenWorkspacesStorage = {
   async _ensureTable() {
     await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage._ensureTable", async db => {
       await db.execute(`
-        CREATE TABLE IF NOT EXISTS moz_workspaces (
+        CREATE TABLE IF NOT EXISTS zen_workspaces (
           id INTEGER PRIMARY KEY,
           uuid TEXT UNIQUE NOT NULL,
           name TEXT NOT NULL,
@@ -26,11 +26,11 @@ var ZenWorkspacesStorage = {
     await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage.saveWorkspace", async db => {
       const now = Date.now();
       await db.executeCached(`
-        INSERT OR REPLACE INTO moz_workspaces (
+        INSERT OR REPLACE INTO zen_workspaces (
           uuid, name, icon, is_default, is_active, container_id, created_at, updated_at
         ) VALUES (
           :uuid, :name, :icon, :is_default, :is_active, :container_id, 
-          COALESCE((SELECT created_at FROM moz_workspaces WHERE uuid = :uuid), :now),
+          COALESCE((SELECT created_at FROM zen_workspaces WHERE uuid = :uuid), :now),
           :now
         )
       `, {
@@ -48,7 +48,7 @@ var ZenWorkspacesStorage = {
   async getWorkspaces() {
     const db = await PlacesUtils.promiseDBConnection();
     const rows = await db.execute(`
-      SELECT * FROM moz_workspaces ORDER BY created_at ASC
+      SELECT * FROM zen_workspaces ORDER BY created_at ASC
     `);
 
     return rows.map(row => ({
@@ -64,7 +64,7 @@ var ZenWorkspacesStorage = {
   async removeWorkspace(uuid) {
     await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage.removeWorkspace", async db => {
       await db.execute(`
-        DELETE FROM moz_workspaces WHERE uuid = :uuid
+        DELETE FROM zen_workspaces WHERE uuid = :uuid
       `, { uuid });
     });
   },
@@ -72,8 +72,8 @@ var ZenWorkspacesStorage = {
   async setActiveWorkspace(uuid) {
     await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage.setActiveWorkspace", async db => {
       await db.executeTransaction(async function() {
-        await db.execute(`UPDATE moz_workspaces SET is_active = 0`);
-        await db.execute(`UPDATE moz_workspaces SET is_active = 1 WHERE uuid = :uuid`, { uuid });
+        await db.execute(`UPDATE zen_workspaces SET is_active = 0`);
+        await db.execute(`UPDATE zen_workspaces SET is_active = 1 WHERE uuid = :uuid`, { uuid });
       });
     });
   },
@@ -81,8 +81,8 @@ var ZenWorkspacesStorage = {
   async setDefaultWorkspace(uuid) {
     await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage.setDefaultWorkspace", async db => {
       await db.executeTransaction(async function() {
-        await db.execute(`UPDATE moz_workspaces SET is_default = 0`);
-        await db.execute(`UPDATE moz_workspaces SET is_default = 1 WHERE uuid = :uuid`, { uuid });
+        await db.execute(`UPDATE zen_workspaces SET is_default = 0`);
+        await db.execute(`UPDATE zen_workspaces SET is_default = 1 WHERE uuid = :uuid`, { uuid });
       });
     });
   }

--- a/src/ZenWorkspacesStorage.mjs
+++ b/src/ZenWorkspacesStorage.mjs
@@ -1,0 +1,89 @@
+var ZenWorkspacesStorage = {
+  async init() {
+    console.log('ZenWorkspacesStorage: Initializing...');
+    await this._ensureTable();
+  },
+
+  async _ensureTable() {
+    await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage._ensureTable", async db => {
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS moz_workspaces (
+          id INTEGER PRIMARY KEY,
+          uuid TEXT UNIQUE NOT NULL,
+          name TEXT NOT NULL,
+          icon TEXT,
+          is_default INTEGER NOT NULL DEFAULT 0,
+          is_active INTEGER NOT NULL DEFAULT 0,
+          container_id INTEGER,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `);
+    });
+  },
+
+  async saveWorkspace(workspace) {
+    await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage.saveWorkspace", async db => {
+      const now = Date.now();
+      await db.executeCached(`
+        INSERT OR REPLACE INTO moz_workspaces (
+          uuid, name, icon, is_default, is_active, container_id, created_at, updated_at
+        ) VALUES (
+          :uuid, :name, :icon, :is_default, :is_active, :container_id, 
+          COALESCE((SELECT created_at FROM moz_workspaces WHERE uuid = :uuid), :now),
+          :now
+        )
+      `, {
+        uuid: workspace.uuid,
+        name: workspace.name,
+        icon: workspace.icon || null,
+        is_default: workspace.default ? 1 : 0,
+        is_active: workspace.used ? 1 : 0,
+        container_id: workspace.containerTabId || null,
+        now
+      });
+    });
+  },
+
+  async getWorkspaces() {
+    const db = await PlacesUtils.promiseDBConnection();
+    const rows = await db.execute(`
+      SELECT * FROM moz_workspaces ORDER BY created_at ASC
+    `);
+
+    return rows.map(row => ({
+      uuid: row.getResultByName("uuid"),
+      name: row.getResultByName("name"),
+      icon: row.getResultByName("icon"),
+      default: !!row.getResultByName("is_default"),
+      used: !!row.getResultByName("is_active"),
+      containerTabId: row.getResultByName("container_id")
+    }));
+  },
+
+  async removeWorkspace(uuid) {
+    await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage.removeWorkspace", async db => {
+      await db.execute(`
+        DELETE FROM moz_workspaces WHERE uuid = :uuid
+      `, { uuid });
+    });
+  },
+
+  async setActiveWorkspace(uuid) {
+    await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage.setActiveWorkspace", async db => {
+      await db.executeTransaction(async function() {
+        await db.execute(`UPDATE moz_workspaces SET is_active = 0`);
+        await db.execute(`UPDATE moz_workspaces SET is_active = 1 WHERE uuid = :uuid`, { uuid });
+      });
+    });
+  },
+
+  async setDefaultWorkspace(uuid) {
+    await PlacesUtils.withConnectionWrapper("ZenWorkspacesStorage.setDefaultWorkspace", async db => {
+      await db.executeTransaction(async function() {
+        await db.execute(`UPDATE moz_workspaces SET is_default = 0`);
+        await db.execute(`UPDATE moz_workspaces SET is_default = 1 WHERE uuid = :uuid`, { uuid });
+      });
+    });
+  }
+};


### PR DESCRIPTION
This PR introduces a new `ZenWorkspacesStorage` class to handle the persistence of workspaces in a database. The previous implementation used JSON files, but this approach brings several advantages, including:

- Improved performance and scalability
- Easier data management and future synchronization implementation
- Enhanced security and data integrity

This change removes the reliance on JSON files and streamlines workspace management, leading to a more robust and reliable system.

Depends on https://github.com/zen-browser/desktop/pull/1870