### PR TITLE
Fully customizable splitview using drag and drop

### DIFF
--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -614,7 +614,9 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
     if (existingSplitTab) {
       const groupIndex = this._data.findIndex((group) => group.tabs.includes(existingSplitTab));
       const group = this._data[groupIndex];
-      if (gridType && (group.gridType !== gridType)) {
+      const gridTypeChange = gridType && (group.gridType !== gridType);
+      const newTabsAdded = tabs.find(t => !group.tabs.includes(t));
+      if (gridTypeChange || !newTabsAdded) {
         // reset layout
         group.gridType = gridType;
         group.layoutTree = this.calculateLayoutTree([...new Set(group.tabs.concat(tabs))], gridType);

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -67,7 +67,7 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
   _tabToSplitNode = new Map();
   dropZone;
   _edgeHoverSize = 20;
-  _minResizeWidth;
+  minResizeWidth;
 
   init() {
     XPCOMUtils.defineLazyPreferenceGetter(this, 'canChangeTabOnHover', 'zen.splitView.change-on-hover', false);
@@ -150,8 +150,8 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
     const childIndex = parent.children.indexOf(toRemove);
     parent.children.splice(childIndex, 1);
     if (parent.children.length !== 1) {
-      const nodeToResize = parent.children[Math.max(0, childIndex - 1)];
-      nodeToResize.sizeInParent += toRemove.sizeInParent;
+      const otherNodeIncrease = 100 / (100 - toRemove.sizeInParent);
+      parent.children.forEach(c => c.sizeInParent *= otherNodeIncrease);
       return parent;
     }
     // node that is not a leaf cannot have less than 2 children, this makes for better resizing

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -692,6 +692,7 @@ var gZenViewSplitter = new class {
       currentSplitters.push(
         this.createSplitter(parentNode.direction === 'column' ? 'horizontal' : 'vertical', parentNode, i)
       );
+      currentSplitters[i].parentSplitNode = parentNode;
     }
     if (currentSplitters.length > splittersNeeded) {
       currentSplitters.slice(splittersNeeded - currentSplitters.length).forEach(s => s.remove());
@@ -779,7 +780,7 @@ var gZenViewSplitter = new class {
     setCursor(isVertical ? 'ew-resize' : 'n-resize');
     document.addEventListener('mousemove', dragFunc);
     document.addEventListener('mouseup', () => {
-      removeEventListener('mousemove', dragFunc);
+      document.removeEventListener('mousemove', dragFunc);
       setCursor('auto');
     }, {once: true});
   }

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -66,12 +66,13 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
   _splitNodeToSplitters = new Map();
   _tabToSplitNode = new Map();
   dropZone;
-  _edgeHoverSize = 20;
+  _edgeHoverSize;
   minResizeWidth;
 
   init() {
     XPCOMUtils.defineLazyPreferenceGetter(this, 'canChangeTabOnHover', 'zen.splitView.change-on-hover', false);
     XPCOMUtils.defineLazyPreferenceGetter(this, 'minResizeWidth', 'zen.splitView.min-resize-width', 7);
+    XPCOMUtils.defineLazyPreferenceGetter(this, '_edgeHoverSize', 'zen.splitView.rearrange-edge-hover-size', 24);
 
     ChromeUtils.defineLazyGetter(
       this,

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -57,25 +57,13 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
   _tabBrowserPanel = null;
   __modifierElement = null;
   __hasSetMenuListener = false;
-  _data = [];
-  currentView = -1;
-  _tabBrowserPanel = null;
-  __modifierElement = null;
-  __hasSetMenuListener = false;
-  canChangeTabOnHover = null;
   splitterBox = null;
   _splitNodeToSplitters = new Map();
   _tabToSplitNode = new Map();
 
   init() {
     XPCOMUtils.defineLazyPreferenceGetter(this, 'canChangeTabOnHover', 'zen.splitView.change-on-hover', false);
-
-    XPCOMUtils.defineLazyPreferenceGetter(
-      this,
-      'minResizeWidth',
-      'zen.splitView.min-resize-width',
-      7
-    );
+    XPCOMUtils.defineLazyPreferenceGetter(this, 'minResizeWidth', 'zen.splitView.min-resize-width', 7);
 
     ChromeUtils.defineLazyGetter(
       this,

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -780,6 +780,7 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
   };
 
   handleSplitterMouseDown = (event) => {
+    this.tabBrowserPanel.setAttribute('zen-split-resizing', true);
     const isVertical = event.target.getAttribute('orient') === 'vertical';
     const dimension = isVertical ? 'width' : 'height';
     const dimensionInParent = dimension + 'InParent';
@@ -821,6 +822,7 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
     document.addEventListener('mouseup', () => {
       document.removeEventListener('mousemove', dragFunc);
       setCursor('auto');
+      this.tabBrowserPanel.removeAttribute('zen-split-resizing');
     }, {once: true});
   }
 

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -929,6 +929,7 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
       // zenModeActive allow us to avoid setting docShellisActive to false later on,
       // see browser-custom-elements.js's patch
       tab.linkedBrowser.zenModeActive = active;
+      if (!active && tab === gBrowser.selectedTab) continue;
       try {
         tab.linkedBrowser.docShellIsActive = active;
       } catch (e) {

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -411,7 +411,7 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
       node.parent.children[nodeIndex] = newParent;
       newParent.addChild(node);
     }
-    node.sizeInParent = 100 - (nodeSize * sizeOfInsertedNode);
+    node.sizeInParent = (1 - sizeOfInsertedNode) * nodeSize;
     nodeToInsert.sizeInParent = nodeSize * sizeOfInsertedNode;
 
     const index = newParent.children.indexOf(node);

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -185,10 +185,10 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
     if (node.children) node.children.forEach(c => this._removeNodeSplitters(c));
   }
 
-  enableTabSwitchView() {
-    if (this.switchViewEnabled) return;
-    this.switchViewEnabled = true;
-    this.switchViewView = this.currentView;
+  enableTabRearrangeView() {
+    if (this.rearrangeViewEnabled) return;
+    this.rearrangeViewEnabled = true;
+    this.rearrangeViewView = this.currentView;
     if (!this._thumnailCanvas) {
       this._thumnailCanvas = document.createElement("canvas");
       this._thumnailCanvas.width = 280 * devicePixelRatio;
@@ -204,30 +204,30 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
     this.tabBrowserPanel.addEventListener('dragover', this.onBrowserDragOver);
     this.tabBrowserPanel.addEventListener('drop', this.onBrowserDrop);
     this.tabBrowserPanel.addEventListener('dragend', this.onBrowserDragEnd)
-    this.tabBrowserPanel.addEventListener('click', this.disableTabSwitchView);
+    this.tabBrowserPanel.addEventListener('click', this.disableTabRearrangeView);
   }
 
-  disableTabSwitchView = (event = null) => {
-    if (!this.switchViewEnabled) return;
+  disableTabRearrangeView = (event = null) => {
+    if (!this.rearrangeViewEnabled) return;
     if (event) {
       if (event.type === 'click' && event.button !== 0) return;
     }
 
-    if (!this.switchViewEnabled || (event && event.target.classList.contains('zen-split-view-splitter'))) {
+    if (!this.rearrangeViewEnabled || (event && event.target.classList.contains('zen-split-view-splitter'))) {
       return;
     }
 
     this.tabBrowserPanel.removeEventListener('dragstart', this.onBrowserDragStart);
     this.tabBrowserPanel.removeEventListener('dragover', this.onBrowserDragOver);
     this.tabBrowserPanel.removeEventListener('drop', this.onBrowserDrop);
-    this.tabBrowserPanel.removeEventListener('click', this.disableTabSwitchView);
-    const browsers = this._data[this.switchViewView].tabs.map(t => t.linkedBrowser);
+    this.tabBrowserPanel.removeEventListener('click', this.disableTabRearrangeView);
+    const browsers = this._data[this.rearrangeViewView].tabs.map(t => t.linkedBrowser);
     browsers.forEach(b => {
       b.style.pointerEvents = '';
       b.style.opacity = '';
     });
-    this.switchViewEnabled = false;
-    this.switchViewView = null;
+    this.rearrangeViewEnabled = false;
+    this.rearrangeViewView = null;
   }
 
   onBrowserDragStart = (event) => {
@@ -666,7 +666,7 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
       this.deactivateCurrentSplitView();
       return;
     }
-    this.disableTabSwitchView();
+    this.disableTabRearrangeView();
     this.activateSplitView(this._data[newView]);
   }
 
@@ -863,7 +863,7 @@ class ZenViewSplitter extends ZenDOMOperatedFeature {
    * @param {Event} event - The event.
    */
   handleTabEvent = (event) => {
-    if (this.switchViewEnabled || (event.type === 'mouseover' && !this.canChangeTabOnHover)) {
+    if (this.rearrangeViewEnabled || (event.type === 'mouseover' && !this.canChangeTabOnHover)) {
       return;
     }
     const container = event.currentTarget;

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -673,6 +673,7 @@ var gZenViewSplitter = new class {
 
     const dragFunc = (dEvent) => {
       requestAnimationFrame(() => {
+        originalSizes.forEach((s, i) => splitNode.children[i][dimensionInParent] = s); // reset changes
 
         const movement = dEvent[clientAxis] - startPosition;
         let movementPercent = (movement / this.tabBrowserPanel.getBoundingClientRect()[dimension] * rootToNodeSize) * 100;
@@ -692,14 +693,13 @@ var gZenViewSplitter = new class {
         this.applyGridLayout(splitNode);
       });
     }
-    const stopListeners = () => {
-      removeEventListener('mousemove', dragFunc);
-      removeEventListener('mouseup', stopListeners);
-      setCursor('auto');
-    }
-    addEventListener('mousemove', dragFunc);
-    addEventListener('mouseup', stopListeners);
+
     setCursor(isVertical ? 'ew-resize' : 'n-resize');
+    document.addEventListener('mousemove', dragFunc);
+    document.addEventListener('mouseup', () => {
+      removeEventListener('mousemove', dragFunc);
+      setCursor('auto');
+    }, {once: true});
   }
 
   /**

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -160,12 +160,13 @@ var gZenViewSplitter = new class {
       leftOverChild.parent = parent.parent;
       parent.parent.children[parent.parent.children.indexOf(parent)] = leftOverChild;
       this._removeNodeSplitters(parent, false);
+      this.applyGridLayout(parent.parent);
     } else {
-      const viewData = Object.entries(this._data).find(s => s.layoutTree === parent);
+      const viewData = Object.values(this._data).find(s => s.layoutTree === parent);
       viewData.layoutTree = parent;
       parent.positionToRoot = null;
+      this.applyGridLayout(parent);
     }
-    this.applyGridLayout(parent.parent, true);
   }
 
   /**
@@ -676,12 +677,6 @@ var gZenViewSplitter = new class {
     splitter.setAttribute('gridIdx', idx);
     this.splitterBox.insertAdjacentElement("afterbegin", splitter);
 
-    splitter.parentSplitNode = parentNode;
-    if (!this._splitNodeToSplitters.has(parentNode)) {
-      this._splitNodeToSplitters.set(parentNode, []);
-    }
-    this._splitNodeToSplitters.get(parentNode).push(splitter);
-
     splitter.addEventListener('mousedown', this.handleSplitterMouseDown);
     return splitter;
   }
@@ -699,14 +694,15 @@ var gZenViewSplitter = new class {
       );
     }
     if (currentSplitters.length > splittersNeeded) {
-      currentSplitters.slice(currentSplitters - splittersNeeded).forEach(s => s.remove());
+      currentSplitters.slice(splittersNeeded - currentSplitters.length).forEach(s => s.remove());
       currentSplitters = currentSplitters.slice(0, splittersNeeded);
     }
+    this._splitNodeToSplitters.set(parentNode, currentSplitters);
     return currentSplitters;
   }
 
   removeSplitters() {
-    Array.from(this._splitNodeToSplitters.values()).forEach(s => s.remove());
+    Array.from(this._splitNodeToSplitters.values())[0].forEach(e => e.remove());
     this._splitNodeToSplitters.clear();
   }
 

--- a/src/ZenViewSplitter.mjs
+++ b/src/ZenViewSplitter.mjs
@@ -379,15 +379,18 @@ var gZenViewSplitter = new class {
     for (let i = 0; i < rows.length; i++) {
       let nextRow = '';
       finalTemplateAreas += `'`;
-      let buildingHSplitter = false;
       for (let j = 0; j < rows[i].length; j++) {
         const current = rows[i][j];
         const rightNeighbor = rows[i][j + 1];
         finalTemplateAreas += " " + current;
-        if (rightNeighbor && rightNeighbor !== current) {
-          finalTemplateAreas += ` vSplitter${vSplitterCount + 1}`;
-          vSplitterCount++;
-          splitters.push({nr: vSplitterCount, orient: 'vertical', gridIdx: j + 1});
+        if (rightNeighbor) {
+          if (rightNeighbor !== current) {
+            finalTemplateAreas += ` vSplitter${vSplitterCount + 1}`;
+            vSplitterCount++;
+            splitters.push({nr: vSplitterCount, orient: 'vertical', gridIdx: j + 1, panels: current + 1});
+          } else {
+            finalTemplateAreas += " " + current;
+          }
         }
 
         if (!rows[i + 1]) {
@@ -396,19 +399,16 @@ var gZenViewSplitter = new class {
         const underNeighbor = rows[i + 1][j];
         if (underNeighbor !== current) {
           nextRow += ` hSplitter${hSplitterCount + 1}`;
-          buildingHSplitter = true;
+          hSplitterCount++;
+          let panels = 1;
+          while (rows[i][j - panels] === current) {
+            panels++;
+          }
+          splitters.push({nr: hSplitterCount, orient: 'horizontal', gridIdx: i + 1, panels: panels});
         } else {
           nextRow += ' ' + current;
-          hSplitterCount++;
-          splitters.push({nr: hSplitterCount, orient: 'horizontal', gridIdx: i + 1});
-          buildingHSplitter = false;
         }
         if (j === rows[i].length - 1) {
-          if (buildingHSplitter) {
-            hSplitterCount++;
-            splitters.push({nr: hSplitterCount, orient: 'horizontal', gridIdx: i + 1});
-            buildingHSplitter = false;
-          }
           continue;
         }
         const rightNeighborJoinedWithUnderNeighbor = rightNeighbor === rows[i + 1][j + 1];


### PR DESCRIPTION
Make split view fully customizable by allowing users to drag and drop the windows around.

This pr is a rewrite of original splitview (no longer uses a css grid).
The rewritten version uses a Tree to store the layout of the grid.

Each node stores it's size (percentage) relative to the parent.
Non leaf nodes have at least 2 children and have a direction ('row' or 'column').
Leaf nodes are linked to a tab.

This allows the view to be fully customizable and resize correctly.

Linked desktop pr: https://github.com/zen-browser/desktop/pull/1914

https://github.com/user-attachments/assets/88e8bacc-182d-4632-87f3-23f22f02085d

