### PR TITLE
Feature: Add pinned tab url resetting functionality

### DIFF
--- a/src/ZenKeyboardShortcuts.mjs
+++ b/src/ZenKeyboardShortcuts.mjs
@@ -642,6 +642,17 @@ function zenGetDefaultShortcuts() {
       'zen-sidebar-shortcut-toggle'
     )
   );
+  newShortcutList.push(
+      new KeyShortcut(
+          'zen-pinned-tab-reset-shortcut',
+          '',
+          '',
+          ZEN_OTHER_SHORTCUTS_GROUP,
+          KeyShortcutModifiers.fromObject({}),
+          'code:gZenPinnedTabManager.resetPinnedTab(gBrowser.selectedTab)',
+          'zen-pinned-tab-shortcut-reset'
+      )
+  );
 
   // Split view
   newShortcutList.push(

--- a/src/ZenPinnedTabManager.mjs
+++ b/src/ZenPinnedTabManager.mjs
@@ -1,160 +1,180 @@
-class ZenPinnedTabsObserver {
-  static ALL_EVENTS = ['TabPinned', 'TabUnpinned'];
+{
+  const lazy = {};
 
-  #listeners = [];
+  XPCOMUtils.defineLazyPreferenceGetter(lazy, 'zenPinnedTabRestorePinnedTabsToPinnedUrl', 'zen.pinned-tab-manager.restore-pinned-tabs-to-pinned-url', false);
+  XPCOMUtils.defineLazyPreferenceGetter(lazy, 'zenPinnedTabResetOnCloseShortcut', 'zen.pinned-tab-manager.reset-pinned-tab-on-close-shortcut', false);
 
-  constructor() {
-    this.#listenPinnedTabEvents();
-  }
+  class ZenPinnedTabsObserver {
+    static ALL_EVENTS = ['TabPinned', 'TabUnpinned'];
 
-  #listenPinnedTabEvents() {
-    const eventListener = this.#eventListener.bind(this);
-    for (const event of ZenPinnedTabsObserver.ALL_EVENTS) {
-      window.addEventListener(event, eventListener);
+    #listeners = [];
+
+    constructor() {
+      this.#listenPinnedTabEvents();
     }
-    window.addEventListener('unload', () => {
+
+    #listenPinnedTabEvents() {
+      const eventListener = this.#eventListener.bind(this);
       for (const event of ZenPinnedTabsObserver.ALL_EVENTS) {
-        window.removeEventListener(event, eventListener);
+        window.addEventListener(event, eventListener);
       }
-    });
-  }
-
-  #eventListener(event) {
-    for (const listener of this.#listeners) {
-      listener(event.type, event);
-    }
-  }
-
-  addPinnedTabListener(listener) {
-    this.#listeners.push(listener);
-  }
-}
-
-class ZenPinnedTabManager {
-  init() {
-    this.observer = new ZenPinnedTabsObserver();
-    this._initClosePinnedTabShortcut();
-    this.insertItemsIntoTabContextMenu();
-    this.observer.addPinnedTabListener(this._onPinnedTabEvent.bind(this));
-  }
-
-  _onPinnedTabEvent(action, event) {
-    const tab = event.target;
-    switch (action) {
-      case "TabPinned":
-        this._setPinnedAttributes(tab);
-        break;
-      case "TabUnpinned":
-        this._removePinnedAttributes(tab);
-        break;
-      default:
-        console.warn('ZenPinnedTabManager: Unhandled tab event', action);
-        break;
-    }
-  }
-
-  resetPinnedTab(tab) {
-
-    if(!tab){
-      tab = TabContextMenu.contextTab;
-    }
-
-    if (!tab || !tab.pinned) {
-      return;
-    }
-
-    const url = tab.getAttribute("zen-pinned-url");
-    const title = tab.getAttribute("zen-pinned-title");
-    const icon = tab.getAttribute("zen-pinned-icon");
-
-    if (url) {
-      const tabState = SessionStore.getTabState(tab);
-      const state = JSON.parse(tabState);
-
-      state.entries = [{url, title}];
-      state.image = icon;
-      state.index = 0;
-
-      SessionStore.setTabState(tab, state);
-    }
-  }
-
-  replacePinnedUrlWithCurrent(){
-    const tab = TabContextMenu.contextTab;
-    if (!tab || !tab.pinned) {
-      return;
-    }
-
-    this._setPinnedAttributes(tab);
-  }
-
-  _setPinnedAttributes(tab) {
-    tab.setAttribute("zen-pinned-url", tab.linkedBrowser.currentURI.spec);
-    tab.setAttribute("zen-pinned-title", tab.getAttribute("label"));
-    tab.setAttribute("zen-pinned-icon", tab.linkedBrowser.mIconURL);
-  }
-
-  _removePinnedAttributes(tab) {
-    tab.removeAttribute("zen-pinned-url");
-    tab.removeAttribute("zen-pinned-title");
-    tab.removeAttribute("zen-pinned-icon");
-  }
-
-  _initClosePinnedTabShortcut() {
-    let cmdClose = document.getElementById('cmd_close');
-
-    if (cmdClose) {
-      cmdClose.addEventListener('command', this._onCloseTabShortcut.bind(this));
-    }
-  }
-
-  _onCloseTabShortcut(event) {
-    if (
-        event &&
-        (event.ctrlKey || event.metaKey || event.altKey) &&
-        gBrowser.selectedTab.pinned
-    ) {
-      const selectedTab = gBrowser.selectedTab;
-      const url = selectedTab.getAttribute("zen-pinned-url");
-      const title = selectedTab.getAttribute("zen-pinned-title");
-      const icon = selectedTab.getAttribute("zen-pinned-icon");
-
-      let nextTab = gBrowser.tabContainer.findNextTab(selectedTab, {
-        direction: 1,
-        filter: tab => !tab.hidden && !tab.pinned,
+      window.addEventListener('unload', () => {
+        for (const event of ZenPinnedTabsObserver.ALL_EVENTS) {
+          window.removeEventListener(event, eventListener);
+        }
       });
+    }
 
-      if (!nextTab) {
-        nextTab = gBrowser.tabContainer.findNextTab(selectedTab, {
-          direction: -1,
+    #eventListener(event) {
+      for (const listener of this.#listeners) {
+        listener(event.type, event);
+      }
+    }
+
+    addPinnedTabListener(listener) {
+      this.#listeners.push(listener);
+    }
+  }
+
+  class ZenPinnedTabManager {
+    init() {
+      this.observer = new ZenPinnedTabsObserver();
+      this._initClosePinnedTabShortcut();
+      this._insertItemsIntoTabContextMenu();
+      this.observer.addPinnedTabListener(this._onPinnedTabEvent.bind(this));
+    }
+
+    _onPinnedTabEvent(action, event) {
+      const tab = event.target;
+      switch (action) {
+        case "TabPinned":
+          this._setPinnedAttributes(tab);
+          break;
+        case "TabUnpinned":
+          this._removePinnedAttributes(tab);
+          break;
+        default:
+          console.warn('ZenPinnedTabManager: Unhandled tab event', action);
+          break;
+      }
+    }
+
+    resetPinnedTab(tab) {
+
+      if (!tab) {
+        tab = TabContextMenu.contextTab;
+      }
+
+      if (!tab || !tab.pinned) {
+        return;
+      }
+
+      this._resetTabToStoredState(tab);
+    }
+
+    replacePinnedUrlWithCurrent() {
+      const tab = TabContextMenu.contextTab;
+      if (!tab || !tab.pinned) {
+        return;
+      }
+
+      this._setPinnedAttributes(tab);
+    }
+
+    _setPinnedAttributes(tab) {
+      tab.setAttribute("zen-pinned-url", tab.linkedBrowser.currentURI.spec);
+      tab.setAttribute("zen-pinned-title", tab.getAttribute("label"));
+      tab.setAttribute("zen-pinned-icon", tab.linkedBrowser.mIconURL);
+    }
+
+    _removePinnedAttributes(tab) {
+      tab.removeAttribute("zen-pinned-url");
+      tab.removeAttribute("zen-pinned-title");
+      tab.removeAttribute("zen-pinned-icon");
+    }
+
+    _initClosePinnedTabShortcut() {
+      let cmdClose = document.getElementById('cmd_close');
+
+      if (cmdClose) {
+        cmdClose.addEventListener('command', this._onCloseTabShortcut.bind(this));
+      }
+    }
+
+    setPinnedTabState(tabData, tab) {
+      tabData.zenPinnedUrl = tab.getAttribute("zen-pinned-url");
+      tabData.zenPinnedTitle = tab.getAttribute("zen-pinned-title");
+      tabData.zenPinnedIcon = tab.getAttribute("zen-pinned-icon");
+    }
+
+    updatePinnedTabForSessionRestore(tabData, tab) {
+      if (tabData.zenPinnedUrl) {
+        tab.setAttribute("zen-pinned-url", tabData.zenPinnedUrl);
+      }
+
+      if (tabData.zenPinnedTitle) {
+        tab.setAttribute("zen-pinned-title", tabData.zenPinnedTitle);
+      }
+
+      if(tabData.zenPinnedIcon) {
+        tab.setAttribute("zen-pinned-icon", tabData.zenPinnedIcon);
+      }
+    }
+
+    _onCloseTabShortcut(event) {
+      if (
+          event &&
+          (event.ctrlKey || event.metaKey || event.altKey) &&
+          gBrowser.selectedTab.pinned
+      ) {
+        const selectedTab = gBrowser.selectedTab;
+
+        let nextTab = gBrowser.tabContainer.findNextTab(selectedTab, {
+          direction: 1,
           filter: tab => !tab.hidden && !tab.pinned,
         });
-      }
 
-      if (selectedTab) {
-        gBrowser.selectedTab = nextTab;
-
-        if (url && Services.prefs.getBoolPref('zen.pinned-tab-manager.reset-pinned-tab-on-close-shortcut',false)) {
-          const tabState = SessionStore.getTabState(selectedTab);
-          const state = JSON.parse(tabState);
-
-          state.entries = [{url, title}];
-          state.image = icon;
-          state.index = 0;
-
-          SessionStore.setTabState(selectedTab, state);
+        if (!nextTab) {
+          nextTab = gBrowser.tabContainer.findNextTab(selectedTab, {
+            direction: -1,
+            filter: tab => !tab.hidden && !tab.pinned,
+          });
         }
 
-        gBrowser.discardBrowser(selectedTab);
+        if (selectedTab) {
+          gBrowser.selectedTab = nextTab;
 
-        event.stopPropagation();
-        event.preventDefault();
+          if (lazy.zenPinnedTabResetOnCloseShortcut) {
+            this._resetTabToStoredState(selectedTab);
+          }
+
+          gBrowser.discardBrowser(selectedTab);
+
+          event.stopPropagation();
+          event.preventDefault();
+        }
       }
     }
-  }
 
-  insertItemsIntoTabContextMenu() {
-    const elements = window.MozXULElement.parseXULToFragment(`
+    _resetTabToStoredState(tab) {
+      const url = tab.getAttribute("zen-pinned-url");
+      const title = tab.getAttribute("zen-pinned-title");
+      const icon = tab.getAttribute("zen-pinned-icon");
+
+      if (url) {
+        const tabState = SessionStore.getTabState(tab);
+        const state = JSON.parse(tabState);
+
+        state.entries = [{url, title}];
+        state.image = icon;
+        state.index = 0;
+
+        SessionStore.setTabState(tab, state);
+      }
+    }
+
+    _insertItemsIntoTabContextMenu() {
+      const elements = window.MozXULElement.parseXULToFragment(`
             <menuitem id="context_zen-replace-pinned-url-with-current"
                       data-lazy-l10n-id="tab-context-zen-replace-pinned-url-with-current"
                       hidden="true"
@@ -164,8 +184,23 @@ class ZenPinnedTabManager {
                       hidden="true"
                       oncommand="gZenPinnedTabManager.resetPinnedTab();"/>
         `);
-    document.getElementById('tabContextMenu').appendChild(elements);
-  }
-}
+      document.getElementById('tabContextMenu').appendChild(elements);
+    }
 
-window.gZenPinnedTabManager = new ZenPinnedTabManager();
+    resetPinnedTabData(tabData) {
+      if (lazy.zenPinnedTabRestorePinnedTabsToPinnedUrl && tabData.pinned && tabData.zenPinnedUrl) {
+        tabData.entries = [{url: tabData.zenPinnedUrl, title: tabData.zenPinnedTitle}];
+        tabData.image = tabData.zenPinnedIcon;
+        tabData.index = 0;
+      }
+    }
+
+    updatePinnedTabContextMenu(contextTab) {
+      const isVisible = contextTab.pinned && contextTab.getAttribute("zen-pinned-url") && !contextTab.multiselected;
+      document.getElementById("context_zen-reset-pinned-tab").hidden = !isVisible;
+      document.getElementById("context_zen-replace-pinned-url-with-current").hidden = !isVisible;
+    }
+  }
+
+  window.gZenPinnedTabManager = new ZenPinnedTabManager();
+}

--- a/src/ZenPinnedTabManager.mjs
+++ b/src/ZenPinnedTabManager.mjs
@@ -1,0 +1,148 @@
+class ZenPinnedTabsObserver {
+  static ALL_EVENTS = ['TabPinned', 'TabUnpinned'];
+
+  #listeners = [];
+
+  constructor() {
+    this.#listenPinnedTabEvents();
+  }
+
+  #listenPinnedTabEvents() {
+    const eventListener = this.#eventListener.bind(this);
+    for (const event of ZenPinnedTabsObserver.ALL_EVENTS) {
+      window.addEventListener(event, eventListener);
+    }
+    window.addEventListener('unload', () => {
+      for (const event of ZenPinnedTabsObserver.ALL_EVENTS) {
+        window.removeEventListener(event, eventListener);
+      }
+    });
+  }
+
+  #eventListener(event) {
+    for (const listener of this.#listeners) {
+      listener(event.type, event);
+    }
+  }
+
+  addPinnedTabListener(listener) {
+    this.#listeners.push(listener);
+  }
+}
+
+class ZenPinnedTabManager {
+  init() {
+    this.observer = new ZenPinnedTabsObserver();
+    this.initClosePinnedTabShortcut();
+    this.insertResetTabIntoContextMenu();
+    this.observer.addPinnedTabListener(this.onPinnedTabEvent.bind(this));
+  }
+
+  onPinnedTabEvent(action, event) {
+    const tab = event.target;
+    switch (action) {
+      case "TabPinned":
+        tab.setAttribute("zen-pinned-url", tab.linkedBrowser.currentURI.spec);
+        tab.setAttribute("zen-pinned-title", tab.getAttribute("label"));
+        break;
+      case "TabUnpinned":
+        tab.removeAttribute("zen-pinned-url");
+        tab.removeAttribute("zen-pinned-title");
+        break;
+      default:
+        console.warn('ZenPinnedTabManager: Unhandled tab event', action);
+        break;
+    }
+  }
+
+  resetPinnedTab(tab) {
+
+    if(!tab){
+      tab = TabContextMenu.contextTab;
+    }
+
+    if (!tab || !tab.pinned) {
+      return;
+    }
+
+    const url = tab.getAttribute("zen-pinned-url");
+    const title = tab.getAttribute("zen-pinned-title");
+
+    if (url) {
+      const tabState = SessionStore.getTabState(tab);
+      const state = JSON.parse(tabState);
+
+      let activeIndex = (state.index || state.entries.length) - 1;
+      activeIndex = Math.min(activeIndex, state.entries.length - 1);
+      activeIndex = Math.max(activeIndex, 0);
+      state.entries[activeIndex].url = url;
+      state.entries[activeIndex].title = title;
+      SessionStore.setTabState(tab, state);
+    }
+  }
+
+  initClosePinnedTabShortcut() {
+    let cmdClose = document.getElementById('cmd_close');
+
+    if (cmdClose) {
+      cmdClose.addEventListener('command', this.onCloseTabShortcut.bind(this));
+    }
+  }
+
+  onCloseTabShortcut(event) {
+    if (
+        event &&
+        (event.ctrlKey || event.metaKey || event.altKey) &&
+        gBrowser.selectedTab.pinned
+    ) {
+      const selectedTab = gBrowser.selectedTab;
+      const url = selectedTab.getAttribute("zen-pinned-url");
+      const title = selectedTab.getAttribute("zen-pinned-title");
+
+      let nextTab = gBrowser.tabContainer.findNextTab(selectedTab, {
+        direction: 1,
+        filter: tab => !tab.hidden && !tab.pinned,
+      });
+
+      if (!nextTab) {
+        nextTab = gBrowser.tabContainer.findNextTab(selectedTab, {
+          direction: -1,
+          filter: tab => !tab.hidden && !tab.pinned,
+        });
+      }
+
+      if (selectedTab) {
+        gBrowser.selectedTab = nextTab;
+
+        if (url && Services.prefs.getBoolPref('zen.pinned-tab-manager.reset-pinned-tab-on-close-shortcut',false)) {
+          const tabState = SessionStore.getTabState(selectedTab);
+          const state = JSON.parse(tabState);
+          let activeIndex = (state.index || state.entries.length) - 1;
+          activeIndex = Math.min(activeIndex, state.entries.length - 1);
+          activeIndex = Math.max(activeIndex, 0);
+          state.entries[activeIndex].url = url;
+          state.entries[activeIndex].title = title;
+          SessionStore.setTabState(selectedTab, state);
+        }
+
+        gBrowser.discardBrowser(selectedTab);
+
+        event.stopPropagation();
+        event.preventDefault();
+      }
+    }
+  }
+
+  insertResetTabIntoContextMenu() {
+    console.log('insertResetTabIntoContextMenu');
+    const element = window.MozXULElement.parseXULToFragment(`
+            <menuitem id="context_zen-reset-pinned-tab"
+                      data-lazy-l10n-id="tab-context-zen-reset-pinned-tab"
+                      hidden="true"
+                      oncommand="gZenPinnedTabManager.resetPinnedTab();"/>
+        `);
+    document.getElementById('tabContextMenu').appendChild(element);
+  }
+}
+
+window.gZenPinnedTabManager = new ZenPinnedTabManager();

--- a/src/ZenPinnedTabManager.mjs
+++ b/src/ZenPinnedTabManager.mjs
@@ -71,18 +71,9 @@ class ZenPinnedTabManager {
       const tabState = SessionStore.getTabState(tab);
       const state = JSON.parse(tabState);
 
-      if(!!state.entries.length) {
-        let activeIndex = (state.index || state.entries.length) - 1;
-        activeIndex = Math.min(activeIndex, state.entries.length - 1);
-        activeIndex = Math.max(activeIndex, 0);
-
-        state.entries[activeIndex].url = url;
-        state.entries[activeIndex].title = title;
-        state.image = icon;
-      } else {
-        state.entries.push({ url, title, image: icon });
-      }
-
+      state.entries = [{url, title}];
+      state.image = icon;
+      state.index = 0;
 
       SessionStore.setTabState(tab, state);
     }
@@ -147,17 +138,9 @@ class ZenPinnedTabManager {
           const tabState = SessionStore.getTabState(selectedTab);
           const state = JSON.parse(tabState);
 
-          if(!!state.entries.length) {
-            let activeIndex = (state.index || state.entries.length) - 1;
-            activeIndex = Math.min(activeIndex, state.entries.length - 1);
-            activeIndex = Math.max(activeIndex, 0);
-
-            state.entries[activeIndex].url = url;
-            state.entries[activeIndex].title = title;
-            state.image = icon;
-          } else {
-            state.entries.push({ url, title, image: icon });
-          }
+          state.entries = [{url, title}];
+          state.image = icon;
+          state.index = 0;
 
           SessionStore.setTabState(selectedTab, state);
         }


### PR DESCRIPTION
This PR introduces a new feature: a pinned tab manager.

- Adds `ZenPinnedTabsObserver` to listen for pinned/unpinned tab events.
- Implements `ZenPinnedTabManager` to handle the logic of managing pinned tabs:
    - Stores pinned tab URLs, titles and icons.
    - Resets the pinned tab to its saved state when closed.
    - Adds a new context menu options to manually reset a pinned tab and to update pinned URL
    - Intercepts a shortcut to close a pinned tab to optionally reset its state.

Depends on:
https://github.com/zen-browser/desktop/pull/1957
https://github.com/zen-browser/l10n-packs/pull/66