### PR TITLE
Fix: Open external links in workspace's default container

### DIFF
--- a/src/ZenWorkspaces.mjs
+++ b/src/ZenWorkspaces.mjs
@@ -874,10 +874,19 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
     });
   }
 
-  getContextIdIfNeeded(userContextId) {
+  getContextIdIfNeeded(userContextId, fromExternal) {
+    if(!this.workspaceEnabled) {
+      return [userContextId, false];
+    }
+
     const activeWorkspace = this.getActiveWorkspaceFromCache();
     const activeWorkspaceUserContextId = activeWorkspace?.containerTabId;
-    if ((typeof userContextId !== 'undefined' && userContextId !== activeWorkspaceUserContextId) || !this.workspaceEnabled) {
+
+    if(fromExternal && !!activeWorkspaceUserContextId) {
+      return [activeWorkspaceUserContextId, true];
+    }
+
+    if (typeof userContextId !== 'undefined' && userContextId !== activeWorkspaceUserContextId) {
       return [userContextId, false];
     }
     return [activeWorkspaceUserContextId, true];

--- a/src/ZenWorkspaces.mjs
+++ b/src/ZenWorkspaces.mjs
@@ -874,7 +874,7 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
     });
   }
 
-  getContextIdIfNeeded(userContextId, fromExternal) {
+  getContextIdIfNeeded(userContextId, fromExternal, allowInheritPrincipal) {
     if(!this.workspaceEnabled) {
       return [userContextId, false];
     }
@@ -882,7 +882,7 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
     const activeWorkspace = this.getActiveWorkspaceFromCache();
     const activeWorkspaceUserContextId = activeWorkspace?.containerTabId;
 
-    if(fromExternal && !!activeWorkspaceUserContextId) {
+    if((fromExternal || allowInheritPrincipal === false) && !!activeWorkspaceUserContextId) {
       return [activeWorkspaceUserContextId, true];
     }
 


### PR DESCRIPTION
This PR modifies the `getContextIdIfNeeded` method to automatically use the active workspace context ID for external calls.

Previously, external calls would use the provided `userContextId` if it was different from the active workspace context ID. Now, if `fromExternal` is true and there's an active workspace, the method will return the active workspace context ID, ensuring consistency with the active workspace.

Depends on: https://github.com/zen-browser/desktop/pull/2081