### PR TITLE
Fixed MacOS window buttons hover in compact mode

### DIFF
--- a/src/ZenCompactMode.mjs
+++ b/src/ZenCompactMode.mjs
@@ -187,6 +187,15 @@ var gZenCompactModeManager = {
       });
 
       target.addEventListener('mouseleave', (event) => {
+        // If on Mac, ignore mouseleave in the area of window buttons
+        if (AppConstants.platform == 'macosx') {
+          const MAC_WINDOW_BUTTONS_X_BORDER = 75;
+          const MAC_WINDOW_BUTTONS_Y_BORDER = 40;
+          if (event.clientX < MAC_WINDOW_BUTTONS_X_BORDER && event.clientY < MAC_WINDOW_BUTTONS_Y_BORDER) {
+            return;
+          }
+        }
+
         if (this.hoverableElements[i].keepHoverDuration) {
           this.flashElement(target, keepHoverDuration, 'has-hover' + target.id, 'zen-has-hover');
         } else {


### PR DESCRIPTION
Fixes https://github.com/zen-browser/desktop/issues/941


https://github.com/user-attachments/assets/40867bc1-6c80-4b5c-953e-09c1f68a139d

