### PR TITLE
Fix: Update gradient generator logic and add theme properties to sync engine

### DIFF
--- a/src/ZenWorkspacesStorage.mjs
+++ b/src/ZenWorkspacesStorage.mjs
@@ -167,6 +167,13 @@ var ZenWorkspacesStorage = {
       default: !!row.getResultByName('is_default'),
       containerTabId: row.getResultByName('container_id'),
       position: row.getResultByName('position'),
+      theme: row.getResultByName('theme_type') ? {
+        type: row.getResultByName('theme_type'),
+        gradientColors: JSON.parse(row.getResultByName('theme_colors')),
+        opacity: row.getResultByName('theme_opacity'),
+        rotation: row.getResultByName('theme_rotation'),
+        texture: row.getResultByName('theme_texture')
+      } : null
     }));
   },
 
@@ -288,32 +295,6 @@ var ZenWorkspacesStorage = {
       await this.markChanged(uuid);
       await this.updateLastChangeTimestamp(db);
     });
-  },
-
-  async getWorkspaceTheme(uuid) {
-    const db = await PlacesUtils.promiseDBConnection();
-    const result = await db.executeCached(`
-      SELECT
-        theme_type,
-        theme_colors,
-        theme_opacity,
-        theme_rotation,
-        theme_texture
-      FROM zen_workspaces
-      WHERE uuid = :uuid
-    `, { uuid });
-
-    if (!result.length || !result[0].getResultByName('theme_type')) {
-      return null;
-    }
-
-    return {
-      type: result[0].getResultByName('theme_type'),
-      gradientColors: JSON.parse(result[0].getResultByName('theme_colors')),
-      opacity: result[0].getResultByName('theme_opacity'),
-      rotation: result[0].getResultByName('theme_rotation'),
-      texture: result[0].getResultByName('theme_texture')
-    };
   },
 
   async getChangedIDs() {

--- a/src/ZenWorkspacesStorage.mjs
+++ b/src/ZenWorkspacesStorage.mjs
@@ -273,7 +273,8 @@ var ZenWorkspacesStorage = {
     });
   },
 
-  async saveWorkspaceTheme(uuid, theme) {
+  async saveWorkspaceTheme(uuid, theme, notifyObservers = true) {
+    const changedUUIDs = [uuid];
     await PlacesUtils.withConnectionWrapper('saveWorkspaceTheme', async (db) => {
       await db.execute(`
         UPDATE zen_workspaces
@@ -298,6 +299,10 @@ var ZenWorkspacesStorage = {
       await this.markChanged(uuid);
       await this.updateLastChangeTimestamp(db);
     });
+
+    if (notifyObservers) {
+      this._notifyWorkspacesChanged("zen-workspace-updated", changedUUIDs);
+    }
   },
 
   async getChangedIDs() {

--- a/src/ZenWorkspacesSync.mjs
+++ b/src/ZenWorkspacesSync.mjs
@@ -20,7 +20,12 @@ Utils.deferGetSet(ZenWorkspaceRecord, "cleartext", [
     "icon",
     "default",
     "containerTabId",
-    "position"
+    "position",
+    "theme_type",
+    "theme_colors",
+    "theme_opacity",
+    "theme_rotation",
+    "theme_texture"
 ]);
 
 // Define ZenWorkspacesStore
@@ -111,6 +116,13 @@ ZenWorkspacesStore.prototype.createRecord = async function (id, collection) {
             record.default = workspace.default;
             record.containerTabId = workspace.containerTabId;
             record.position = workspace.position;
+            if (workspace.theme) {
+                record.theme_type = workspace.theme.type;
+                record.theme_colors = JSON.stringify(workspace.theme.gradientColors);
+                record.theme_opacity = workspace.theme.opacity;
+                record.theme_rotation = workspace.theme.rotation;
+                record.theme_texture = workspace.theme.texture;
+            }
             record.deleted = false;
         } else {
             record.deleted = true;
@@ -136,7 +148,14 @@ ZenWorkspacesStore.prototype.create = async function (record) {
             icon: record.icon,
             default: record.default,
             containerTabId: record.containerTabId,
-            position: record.position
+            position: record.position,
+            theme: record.theme_type ? {
+                type: record.theme_type,
+                gradientColors: JSON.parse(record.theme_colors),
+                opacity: record.theme_opacity,
+                rotation: record.theme_rotation,
+                texture: record.theme_texture
+            } : null
         };
         await ZenWorkspacesStorage.saveWorkspace(workspace,false);
     } catch (error) {
@@ -206,6 +225,30 @@ ZenWorkspacesStore.prototype._validateRecord = function (record) {
     }
     if(record.position != null && typeof record.position !== "number") {
         throw new Error(`Invalid position for workspace ID ${record.id}`);
+    }
+
+    // Validate theme properties if they exist
+    if (record.theme_type) {
+        if (typeof record.theme_type !== "string") {
+            throw new Error(`Invalid theme_type for workspace ID ${record.id}`);
+        }
+        if (!record.theme_colors || typeof record.theme_colors !== "string") {
+            throw new Error(`Invalid theme_colors for workspace ID ${record.id}`);
+        }
+        try {
+            JSON.parse(record.theme_colors);
+        } catch (e) {
+            throw new Error(`Invalid theme_colors JSON for workspace ID ${record.id}`);
+        }
+        if (record.theme_opacity != null && typeof record.theme_opacity !== "number") {
+            throw new Error(`Invalid theme_opacity for workspace ID ${record.id}`);
+        }
+        if (record.theme_rotation != null && typeof record.theme_rotation !== "number") {
+            throw new Error(`Invalid theme_rotation for workspace ID ${record.id}`);
+        }
+        if (record.theme_texture != null && typeof record.theme_texture !== "number") {
+            throw new Error(`Invalid theme_texture for workspace ID ${record.id}`);
+        }
     }
 };
 
@@ -399,7 +442,7 @@ ZenWorkspacesEngine.prototype.constructor = ZenWorkspacesEngine;
 ZenWorkspacesEngine.prototype._storeObj = ZenWorkspacesStore;
 ZenWorkspacesEngine.prototype._trackerObj = ZenWorkspacesTracker;
 ZenWorkspacesEngine.prototype._recordObj = ZenWorkspaceRecord;
-ZenWorkspacesEngine.prototype.version = 1;
+ZenWorkspacesEngine.prototype.version = 2;
 
 ZenWorkspacesEngine.prototype.syncPriority = 10;
 ZenWorkspacesEngine.prototype.allowSkippedRecord = false;


### PR DESCRIPTION
This PR introduces several optimizations to gradient generator and workspaces handling, alongside adding support for syncing of a workspace theme across devices 

The following changes were made:

- Added theme properties to the Zen workspace schema:
    - `theme_type` (string): Type of theme (e.g., "gradient", "solid").
    - `theme_colors` (JSON string): Array of gradient colors.
    - `theme_opacity` (number): Opacity of the theme.
    - `theme_rotation` (number): Rotation of the theme.
    - `theme_texture` (number): Texture of the theme.
- Updated the `ZenWorkspacesSync` class to handle theme data.
- Added validation for theme properties.
- Updated the `ZenWorkspacesStorage` class to save and load workspace themes.
- Bumped the `ZenWorkspacesEngine` version to 2.
- Updated the color theme on panel close instead of on input to reduce writes to the database
- Updated workspace cache invalidating to invalid cache on only workspace updates and not on workspace changing

Depends on:
https://github.com/zen-browser/desktop/pull/2331