### PR TITLE
Fix: Notify theme picker when workspace has synced

### DIFF
--- a/src/ZenWorkspaces.mjs
+++ b/src/ZenWorkspaces.mjs
@@ -65,6 +65,9 @@ var ZenWorkspaces = new (class extends ZenMultiWindowFeature {
           lastChangeTimestamp > this._workspaceCache.lastChangeTimestamp
         ) {
           await this._propagateWorkspaceData();
+
+          const currentWorkspace = await this.getActiveWorkspace();
+          await gZenThemePicker.onWorkspaceChange(currentWorkspace);
         }
       } catch (error) {
         console.error('Error updating workspaces after sync:', error);


### PR DESCRIPTION
This PR updates the workspace sync logic to notify the theme picker when the active workspace has applied changes from sync.

This ensures that the theme picker can update its state and display the correct theme for the current workspace.